### PR TITLE
Speicherleck, Deprecation, parsen

### DIFF
--- a/adapter/pokemonAdapter.go
+++ b/adapter/pokemonAdapter.go
@@ -12,8 +12,8 @@ type Pokemon struct {
 }
 
 func GetRandomPokemon() Pokemon {
-	pokemonResponse := GetPokemonResponse(getRandomInt())
-	speciesResponse := GetSpeciesResponse(pokemonResponse)
+	pokemonResponse, _ := GetPokemonResponse(getRandomInt())
+	speciesResponse, _ := GetSpeciesResponse(pokemonResponse)
 	name := GetGermanName(speciesResponse)
 	fmt.Println(speciesResponse)
 	return Pokemon{

--- a/adapter/pokemonConnector.go
+++ b/adapter/pokemonConnector.go
@@ -3,7 +3,7 @@ package adapter
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
@@ -35,7 +35,9 @@ type OfficialArtwork struct {
 
 func GetPokemonResponse(number int) PokemonResponse {
 	response, _ := http.Get(fmt.Sprintf("https://pokeapi.co/api/v2/pokemon/%d/", number))
-	responseData, _ := ioutil.ReadAll(response.Body)
+	responseData, _ := io.ReadAll(response.Body)
+	defer response.Body.Close()
+
 	var responseObject PokemonResponse
 	json.Unmarshal(responseData, &responseObject)
 	return responseObject

--- a/adapter/pokemonConnector.go
+++ b/adapter/pokemonConnector.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 )
 
@@ -33,12 +34,17 @@ type OfficialArtwork struct {
 	FrontDefault string `json:"front_default"`
 }
 
-func GetPokemonResponse(number int) PokemonResponse {
-	response, _ := http.Get(fmt.Sprintf("https://pokeapi.co/api/v2/pokemon/%d/", number))
-	responseData, _ := io.ReadAll(response.Body)
+func GetPokemonResponse(number int) (PokemonResponse, error) {
+	response, err := http.Get(fmt.Sprintf("https://pokeapi.co/api/v2/pokemon/%d/", number))
+	if err != nil {
+		slog.Warn("error retrieving pokemon: " + err.Error())
+		var empty PokemonResponse
+		return empty, err
+	}
 	defer response.Body.Close()
+	responseData, _ := io.ReadAll(response.Body)
 
 	var responseObject PokemonResponse
 	json.Unmarshal(responseData, &responseObject)
-	return responseObject
+	return responseObject, nil
 }

--- a/adapter/speciesConnector.go
+++ b/adapter/speciesConnector.go
@@ -2,7 +2,7 @@ package adapter
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
@@ -23,7 +23,9 @@ type LanguageStruct struct {
 
 func GetSpeciesResponse(pokemonResponse PokemonResponse) SpeciesResponse {
 	response, _ := http.Get(pokemonResponse.Species.Url)
-	responseData, _ := ioutil.ReadAll(response.Body)
+	responseData, _ := io.ReadAll(response.Body)
+	defer response.Body.Close()
+
 	var responseObject SpeciesResponse
 	json.Unmarshal(responseData, &responseObject)
 	return responseObject

--- a/adapter/speciesConnector.go
+++ b/adapter/speciesConnector.go
@@ -3,6 +3,7 @@ package adapter
 import (
 	"encoding/json"
 	"io"
+	"log/slog"
 	"net/http"
 )
 
@@ -21,14 +22,19 @@ type LanguageStruct struct {
 	Url  string `json:"url"`
 }
 
-func GetSpeciesResponse(pokemonResponse PokemonResponse) SpeciesResponse {
-	response, _ := http.Get(pokemonResponse.Species.Url)
-	responseData, _ := io.ReadAll(response.Body)
+func GetSpeciesResponse(pokemonResponse PokemonResponse) (SpeciesResponse, error) {
+	response, err := http.Get(pokemonResponse.Species.Url)
+	if err != nil {
+		slog.Warn("error retrieving species: " + err.Error())
+		var empty SpeciesResponse
+		return empty, err
+	}
 	defer response.Body.Close()
 
+	responseData, _ := io.ReadAll(response.Body)
 	var responseObject SpeciesResponse
 	json.Unmarshal(responseData, &responseObject)
-	return responseObject
+	return responseObject, nil
 }
 
 func GetGermanName(response SpeciesResponse) string {

--- a/main.go
+++ b/main.go
@@ -2,15 +2,17 @@ package main
 
 import (
 	"fmt"
-	"github.com/MrTimeey/go-live-tracker/adapter"
 	"html/template"
 	"log"
 	"net/http"
+
+	"github.com/MrTimeey/go-live-tracker/adapter"
 )
+
+var tmpl = template.Must(template.ParseFiles("./templates/index.html"))
 
 func main() {
 	templateFunction := func(w http.ResponseWriter, r *http.Request) {
-		tmpl := template.Must(template.ParseFiles("./templates/index.html"))
 		tmpl.Execute(w, adapter.GetRandomPokemon())
 	}
 


### PR DESCRIPTION
- ioutil ist deprecated
- Response bodies müssen nach dem lesen geschlossen werden, damit es nicht zu einem Speicherleck kommt. Darum da auch die Behandlung des Errors. Das `defer response.Body.Close()` darf erst nach der Fehlerbehandlung kommen.
- Es reicht die templates einmal beim Serverstart zu parsen. Das muss nicht bei jedem Request passieren.